### PR TITLE
provide possibilty to provide plain provider

### DIFF
--- a/libs/aws/package.json
+++ b/libs/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/ngx-aws",
-  "version": "3.0.0",
+  "version": "4.0.0-pr20.0",
   "repository": "https://github.com/shiftcode/sc-ng-commons-public",
   "license": "MIT",
   "author": "shiftcode GmbH <team@shiftcode.ch>",

--- a/libs/aws/src/lib/cloudwatch-logger/with-cloudwatch-transport.function.ts
+++ b/libs/aws/src/lib/cloudwatch-logger/with-cloudwatch-transport.function.ts
@@ -2,14 +2,23 @@ import { LOG_TRANSPORTS, LoggerFeature, LoggerFeatureKind } from '@shiftcode/ngx
 import { CLOUD_WATCH_LOG_TRANSPORT_CONFIG } from './cloud-watch-log-transport-config.injection-token'
 import { CloudWatchLogTransportConfig } from './cloud-watch-log-transport-config.model'
 import { CloudWatchLogTransport } from './cloud-watch-log-transport.service'
+import { Provider } from '@angular/core'
+
+function isCloudWatchTransportConfig(v: CloudWatchLogTransportConfig | Provider): v is CloudWatchLogTransportConfig {
+  return (<Array<keyof CloudWatchLogTransportConfig>>[
+    'logLevel',
+    'logGroupName',
+    'clientConfig$',
+    'flushInterval',
+  ]).every((propertyName) => propertyName in v)
+}
 
 export function withCloudwatchTransport(
-  cloudWatchLogTransportConfigOrFactory: CloudWatchLogTransportConfig | (() => CloudWatchLogTransportConfig),
+  cloudWatchLogTransportConfigOrProvider: CloudWatchLogTransportConfig | Provider,
 ): LoggerFeature {
-  const configProvider =
-    typeof cloudWatchLogTransportConfigOrFactory === 'function'
-      ? { provide: CLOUD_WATCH_LOG_TRANSPORT_CONFIG, useFactory: cloudWatchLogTransportConfigOrFactory }
-      : { provide: CLOUD_WATCH_LOG_TRANSPORT_CONFIG, useValue: cloudWatchLogTransportConfigOrFactory }
+  const configProvider: Provider = isCloudWatchTransportConfig(cloudWatchLogTransportConfigOrProvider)
+    ? { provide: CLOUD_WATCH_LOG_TRANSPORT_CONFIG, useValue: cloudWatchLogTransportConfigOrProvider }
+    : cloudWatchLogTransportConfigOrProvider
 
   return {
     kind: LoggerFeatureKind.TRANSPORT,


### PR DESCRIPTION
Add possibility provide the well known providers (current use-case: factory provider with deps) or a CloudWatchLogTransportConfig as before.

BREAKING CHANGE:
Providing a function which is then used as a FactoryProvider is no longer possible. Either provide the CloudWatchLogTransportConfig or a Provider

resolves #20 