### PR TITLE
feat(core): replace abstract class LogRequestInfoProvider with provider function

### DIFF
--- a/libs/core/src/lib/logger/cloudwatch/cloud-watch.service.ts
+++ b/libs/core/src/lib/logger/cloudwatch/cloud-watch.service.ts
@@ -9,8 +9,8 @@ import { CloudWatchLogTransportConfig } from './cloud-watch-log-transport-config
 import { HttpClient } from '@angular/common/http'
 import { isLogStreamNotFoundError } from './is-error.function'
 import { ClientIdService } from '../../client-id/client-id.service'
-import { LogRequestInfoProvider } from '../log-request-info-provider'
 import { RemoteLogData } from '../remote/remote-log-data.model'
+import { LOG_REQUEST_INFO } from '../log-request-info.token'
 
 interface CloudWatchLogEvent {
   logStreamName: string
@@ -34,7 +34,7 @@ export class CloudWatchService {
     private httpClient: HttpClient,
     clientIdService: ClientIdService,
     @Inject(CLOUD_WATCH_LOG_TRANSPORT_CONFIG) private readonly config: CloudWatchLogTransportConfig,
-    @Optional() private logRequestInfoProvider?: LogRequestInfoProvider,
+    @Optional() @Inject(LOG_REQUEST_INFO) private logRequestInfoProvider?: Record<string, string>,
   ) {
     this.clientId = clientIdService.clientId
     this.jsonStringifyReplacer = config.jsonStringifyReplacer || jsonMapSetStringifyReplacer
@@ -61,7 +61,7 @@ export class CloudWatchService {
 
     const logDataObject: RemoteLogData = {
       ...createJsonLogObjectData(level, context, dTimestamp, args),
-      requestInfo: this.logRequestInfoProvider?.getRequestInfo() ?? {},
+      requestInfo: this.logRequestInfoProvider ?? {},
     }
 
     this.logsSubject.next({

--- a/libs/core/src/lib/logger/log-request-info-provider.ts
+++ b/libs/core/src/lib/logger/log-request-info-provider.ts
@@ -1,3 +1,0 @@
-export abstract class LogRequestInfoProvider {
-  abstract getRequestInfo(): Record<string, string>
-}

--- a/libs/core/src/lib/logger/log-request-info.token.ts
+++ b/libs/core/src/lib/logger/log-request-info.token.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core'
+
+export const LOG_REQUEST_INFO = new InjectionToken<Record<string, string>>('LOG_REQUEST_INFO')

--- a/libs/core/src/lib/logger/provide-log-request-info.ts
+++ b/libs/core/src/lib/logger/provide-log-request-info.ts
@@ -1,0 +1,22 @@
+import { EnvironmentProviders, FactoryProvider, makeEnvironmentProviders, ValueProvider } from '@angular/core'
+import { LOG_REQUEST_INFO } from '@shiftcode/ngx-core'
+
+export function provideLogRequestInfo(
+  logRequestInfoOrFactory: Record<string, string> | (() => Record<string, string>),
+): EnvironmentProviders {
+  if (typeof logRequestInfoOrFactory === 'function') {
+    return makeEnvironmentProviders([
+      {
+        provide: LOG_REQUEST_INFO,
+        useFactory: logRequestInfoOrFactory,
+      } satisfies FactoryProvider,
+    ])
+  } else {
+    return makeEnvironmentProviders([
+      {
+        provide: LOG_REQUEST_INFO,
+        useValue: logRequestInfoOrFactory,
+      } satisfies ValueProvider,
+    ])
+  }
+}

--- a/libs/core/src/lib/logger/remote/remote-log.service.ts
+++ b/libs/core/src/lib/logger/remote/remote-log.service.ts
@@ -2,23 +2,23 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http'
 import { Inject, Injectable, Optional } from '@angular/core'
 import { createJsonLogObjectData, LogLevel } from '@shiftcode/logger'
-import { LogRequestInfoProvider } from '../log-request-info-provider'
 import { REMOTE_LOG_CONFIG } from './remote-log-config.injection-token'
 import { RemoteLogConfig } from './remote-log-config.model'
 import { RemoteLogData } from './remote-log-data.model'
+import { LOG_REQUEST_INFO } from '../log-request-info.token'
 
 @Injectable({ providedIn: 'root' })
 export class RemoteLogService {
   protected constructor(
     private httpClient: HttpClient,
     @Inject(REMOTE_LOG_CONFIG) private config: RemoteLogConfig,
-    @Optional() private logRequestInfoProvider?: LogRequestInfoProvider,
+    @Optional() @Inject(LOG_REQUEST_INFO) private logRequestInfoProvider?: Record<string, string>,
   ) {}
 
   sendMessage(level: LogLevel, context: string, timestamp: Date, args: any[]) {
     const remoteLogData: RemoteLogData = {
       ...createJsonLogObjectData(level, context, timestamp, args),
-      requestInfo: this.logRequestInfoProvider?.getRequestInfo() ?? {},
+      requestInfo: this.logRequestInfoProvider ?? {},
     }
     this.postToBackend(remoteLogData)
   }

--- a/libs/core/src/public-api.ts
+++ b/libs/core/src/public-api.ts
@@ -13,7 +13,8 @@ export * from './lib/local-storage/local-storage-options'
 export * from './lib/local-storage/provide-local-storage'
 
 // logger
-export * from './lib/logger/log-request-info-provider'
+export * from './lib/logger/log-request-info.token'
+export * from './lib/logger/provide-log-request-info'
 export * from './lib/logger/logger.service'
 export * from './lib/logger/provide-logger'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1689,7 +1689,6 @@
       "version": "19.0.3",
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.0.3.tgz",
       "integrity": "sha512-cxtK4SlHAPstcXfjwOaoR1dAszrzo2iDF8ZiihbZPgKUG3m27qIU3Lp5XBgxfZPlO4jh6TXkWznY7f6Tyxkb0Q==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1814,7 +1813,6 @@
       "version": "19.0.3",
       "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-19.0.3.tgz",
       "integrity": "sha512-6OnDz15QEhM2sTQKn2tgKzQ6jefSLgJQUiUJFMIhkr6jQSCNvaXLssB8DR7cGIcFK4S/n6+uIxaLaaRo8U69Xw==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.3.0",
         "xhr2": "^0.2.0"
@@ -23065,7 +23063,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.2.1.tgz",
       "integrity": "sha512-sID0rrVCqkVNUn8t6xuv9+6FViXjUVXq8H5rWOH2rz9fDNQEd4g0EA2XlcEdJXRz5BMEn4O1pJFdT+z4YHhoWw==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -23194,7 +23191,6 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.0.tgz",
       "integrity": "sha512-9oxn0IIjbCZkJ67L+LkhYWRyAy7axphb3VgE2MBDlOqnmHMPWGYMxJxBYFueFq/JGY2GMwS0rU+UCLunEmy5UA==",
-      "dev": true,
       "license": "MIT"
     }
   }


### PR DESCRIPTION
according to new angular best-practices we roll out the functionality to `LogRequestInfo` and expose a new function `provideLogRequestInfo` to provide the value / factory for `LOG_REQUEST_INFO` token.

> BREAKING CHANGE:
The abstract class LogRequestInfoProvider is no longer available please provide the value using