### PR TITLE
#87 - testing-fab

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "angular": {
+      "tools": ["*"],
+      "command": "npx",
+      "args": ["@angular/cli", "mcp"]
+    },
+
+    "mdn": {
+      "tools": ["*"],
+      "type": "http",
+      "url": "https://mcp.mdn.mozilla.net",
+      "headers": {}
+    }
+  }
+}

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,9 @@
+# SC NG Commons
+
+Shared Library concepts for reusable frontend capabilities used by Consumer applications.
+
+## Language
+
+**Testing FAB**:
+A floating action button for non-production environments that reveals configurable test and development controls.
+_Avoid_: debug menu, dev button, toolbox

--- a/apps/styleguide/package.json
+++ b/apps/styleguide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/styleguide",
-  "version": "15.3.0-pr87.2",
+  "version": "15.3.0-pr87.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/styleguide/package.json
+++ b/apps/styleguide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/styleguide",
-  "version": "15.3.0-pr87.7",
+  "version": "15.3.0-pr87.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/styleguide/package.json
+++ b/apps/styleguide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/styleguide",
-  "version": "15.3.0-pr87.5",
+  "version": "15.3.0-pr87.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/styleguide/package.json
+++ b/apps/styleguide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/styleguide",
-  "version": "15.3.0-pr87.6",
+  "version": "15.3.0-pr87.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/styleguide/package.json
+++ b/apps/styleguide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/styleguide",
-  "version": "15.3.0-pr87.1",
+  "version": "15.3.0-pr87.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/styleguide/package.json
+++ b/apps/styleguide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/styleguide",
-  "version": "15.3.0-pr87.3",
+  "version": "15.3.0-pr87.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/styleguide/package.json
+++ b/apps/styleguide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/styleguide",
-  "version": "15.3.0-pr87.4",
+  "version": "15.3.0-pr87.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/styleguide/package.json
+++ b/apps/styleguide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/styleguide",
-  "version": "15.3.0-pr87.0",
+  "version": "15.3.0-pr87.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/styleguide/package.json
+++ b/apps/styleguide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/styleguide",
-  "version": "15.2.0",
+  "version": "15.2.1-pr87.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/styleguide/package.json
+++ b/apps/styleguide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/styleguide",
-  "version": "15.2.1-pr87.0",
+  "version": "15.3.0-pr87.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/styleguide/src/main.ts
+++ b/apps/styleguide/src/main.ts
@@ -1,11 +1,19 @@
 import { provideHttpClient } from '@angular/common/http'
-import { provideZoneChangeDetection } from '@angular/core'
+import { DOCUMENT, inject, provideEnvironmentInitializer, provideZoneChangeDetection } from '@angular/core'
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { bootstrapApplication } from '@angular/platform-browser'
 import { provideAnimations } from '@angular/platform-browser/animations'
-import { provideRouter } from '@angular/router'
+import { NavigationEnd, provideRouter, Router } from '@angular/router'
 import { LogLevel } from '@shiftcode/logger'
-import { provideNavigationClassHandler } from '@shiftcode/ngx-components'
-import { provideLocalStorage, provideLogger, withBrowserConsoleTransport } from '@shiftcode/ngx-core'
+import { provideNavigationClassHandler, provideTestingFab } from '@shiftcode/ngx-components'
+import {
+  filterIfInstanceOf,
+  ORIGIN,
+  provideLocalStorage,
+  provideLogger,
+  withBrowserConsoleTransport,
+} from '@shiftcode/ngx-core'
+import { filter, map, startWith } from 'rxjs'
 
 import { AppComponent } from './app/app.component'
 import { provideSgConfig } from './provide-sg-config'
@@ -22,6 +30,52 @@ bootstrapApplication(AppComponent, {
     provideLogger(withBrowserConsoleTransport(() => ({ logLevel: LogLevel.DEBUG }))),
     provideNavigationClassHandler('sg-navigating'),
     provideSgConfig(),
+    provideTestingFab([
+      {
+        id: 'body-bg-color',
+        label: 'Body Background',
+        type: 'select-query-param',
+        queryParam: 'body-bg',
+        options: [
+          { value: '#e0202b', label: 'red' },
+          { value: '#c61c26', label: 'darkRed' },
+          { value: '#e0481e', label: 'orange' },
+          { value: '#bd3c19', label: 'burntOrange' },
+          { value: '#eb701d', label: 'amber' },
+          { value: '#ff7a20', label: 'brightOrange' },
+          { value: '#e3a112', label: 'goldenrod' },
+          { value: '#ffb514', label: 'sunflower' },
+          { value: '#f2eb37', label: 'lemon' },
+          { value: '#e3dc34', label: 'mustard' },
+          { value: '#b2e255', label: 'lime' },
+          { value: '#a3cf4e', label: 'oliveLime' },
+          { value: '#63f1ff', label: 'cyan' },
+          { value: '#4fc1cc', label: 'lightTeal' },
+          { value: '#43a6b0', label: 'teal' },
+          { value: '#35828a', label: 'darkTeal' },
+          { value: '#256960', label: 'forestTeal' },
+          { value: '#39a496', label: 'jade' },
+          { value: '#2c7d73', label: 'seaGreen' },
+          { value: '#35978a', label: 'turquoise' },
+        ],
+      },
+    ]),
+    provideEnvironmentInitializer(() => {
+      const origin = inject(ORIGIN)
+      const doc = inject(DOCUMENT)
+      inject(Router)
+        .events.pipe(
+          takeUntilDestroyed(),
+          filterIfInstanceOf(NavigationEnd),
+          map((ev) => ev.urlAfterRedirects),
+          startWith(inject(Router).url),
+          map((path) => URL.parse(path, origin)?.searchParams?.get('body-bg') || null),
+          filter((bgColor) => bgColor === null || /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(bgColor)),
+        )
+        .subscribe((bgColor) => {
+          doc.body.style.backgroundColor = bgColor || 'unset'
+        })
+    }),
   ],
   // eslint-disable-next-line no-console
 }).catch((err) => console.error(err))

--- a/apps/styleguide/src/main.ts
+++ b/apps/styleguide/src/main.ts
@@ -62,7 +62,8 @@ bootstrapApplication(AppComponent, {
       {
         id: 'body-bg-light',
         type: 'toggle-query-param',
-        label: 'Use Light background',
+        label: 'Lighten Color',
+        title: 'Background',
         queryParam: 'body-bg-light',
       },
     ]),

--- a/apps/styleguide/src/main.ts
+++ b/apps/styleguide/src/main.ts
@@ -13,7 +13,7 @@ import {
   provideLogger,
   withBrowserConsoleTransport,
 } from '@shiftcode/ngx-core'
-import { filter, map, startWith } from 'rxjs'
+import { map, startWith } from 'rxjs'
 
 import { AppComponent } from './app/app.component'
 import { provideSgConfig } from './provide-sg-config'
@@ -33,8 +33,8 @@ bootstrapApplication(AppComponent, {
     provideTestingFab([
       {
         id: 'body-bg-color',
-        label: 'Body Background',
         type: 'select-query-param',
+        label: 'Body Background',
         queryParam: 'body-bg',
         options: [
           { value: '#e0202b', label: 'red' },
@@ -59,6 +59,12 @@ bootstrapApplication(AppComponent, {
           { value: '#35978a', label: 'turquoise' },
         ],
       },
+      {
+        id: 'body-bg-light',
+        type: 'toggle-query-param',
+        label: 'Use Light background',
+        queryParam: 'body-bg-light',
+      },
     ]),
     provideEnvironmentInitializer(() => {
       const origin = inject(ORIGIN)
@@ -69,11 +75,15 @@ bootstrapApplication(AppComponent, {
           filterIfInstanceOf(NavigationEnd),
           map((ev) => ev.urlAfterRedirects),
           startWith(inject(Router).url),
-          map((path) => URL.parse(path, origin)?.searchParams?.get('body-bg') || null),
-          filter((bgColor) => bgColor === null || /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(bgColor)),
+          map((path) => {
+            const qp = URL.parse(path, origin)?.searchParams
+            const bgColor = qp?.get('body-bg') || '#fff'
+            const lightFlag = qp?.get('body-bg-light') === 'true'
+            return [/^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(bgColor) ? bgColor : '#fff', lightFlag] as const
+          }),
         )
-        .subscribe((bgColor) => {
-          doc.body.style.backgroundColor = bgColor || 'unset'
+        .subscribe(([bgColor, useLightBg]) => {
+          doc.body.style.backgroundColor = useLightBg ? `color-mix(in oklab, ${bgColor}, white 50%)` : bgColor
         })
     }),
   ],

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "packages": ["libs/*", "apps/*"],
-  "version": "15.2.1-pr87.0",
+  "version": "15.3.0-pr87.0",
   "command": {
     "version": {
       "allowBranch": "*",

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "packages": ["libs/*", "apps/*"],
-  "version": "15.3.0-pr87.7",
+  "version": "15.3.0-pr87.8",
   "command": {
     "version": {
       "allowBranch": "*",

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "packages": ["libs/*", "apps/*"],
-  "version": "15.3.0-pr87.6",
+  "version": "15.3.0-pr87.7",
   "command": {
     "version": {
       "allowBranch": "*",

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "packages": ["libs/*", "apps/*"],
-  "version": "15.3.0-pr87.3",
+  "version": "15.3.0-pr87.4",
   "command": {
     "version": {
       "allowBranch": "*",

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "packages": ["libs/*", "apps/*"],
-  "version": "15.3.0-pr87.0",
+  "version": "15.3.0-pr87.1",
   "command": {
     "version": {
       "allowBranch": "*",

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "packages": ["libs/*", "apps/*"],
-  "version": "15.2.0",
+  "version": "15.2.1-pr87.0",
   "command": {
     "version": {
       "allowBranch": "*",

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "packages": ["libs/*", "apps/*"],
-  "version": "15.3.0-pr87.1",
+  "version": "15.3.0-pr87.2",
   "command": {
     "version": {
       "allowBranch": "*",

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "packages": ["libs/*", "apps/*"],
-  "version": "15.3.0-pr87.4",
+  "version": "15.3.0-pr87.5",
   "command": {
     "version": {
       "allowBranch": "*",

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "packages": ["libs/*", "apps/*"],
-  "version": "15.3.0-pr87.2",
+  "version": "15.3.0-pr87.3",
   "command": {
     "version": {
       "allowBranch": "*",

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "packages": ["libs/*", "apps/*"],
-  "version": "15.3.0-pr87.5",
+  "version": "15.3.0-pr87.6",
   "command": {
     "version": {
       "allowBranch": "*",

--- a/libs/components/README.md
+++ b/libs/components/README.md
@@ -106,4 +106,4 @@ bootstrapApplication(AppComponent, {
 })
 ```
 
-Add `<sc-testing-fab />` once in a root-level template where it should be available.
+`provideTestingFab(...)` mounts `<sc-testing-fab>` automatically as sibling of `app-root` (when enabled).

--- a/libs/components/README.md
+++ b/libs/components/README.md
@@ -95,6 +95,12 @@ bootstrapApplication(AppComponent, {
           { label: 'Preview', value: 'preview' },
         ],
       },
+      {
+        id: 'enable-feature-x',
+        label: 'Enable Feature X',
+        type: 'toggle-query-param',
+        queryParam: 'feature-x',
+      },
     ]),
   ],
 })

--- a/libs/components/README.md
+++ b/libs/components/README.md
@@ -80,7 +80,7 @@ Can be customized with css custom properties:
 Floating action button for non-production testing controls.
 
 ```ts
-import { provideTestingFab, TestingFabComponent } from '@shiftcode/ngx-components'
+import { provideTestingFab } from '@shiftcode/ngx-components'
 
 bootstrapApplication(AppComponent, {
   providers: [

--- a/libs/components/README.md
+++ b/libs/components/README.md
@@ -74,3 +74,30 @@ Can be customized with css custom properties:
   --sc-tooltip-padding: 4px 8px;
 }
 ```
+
+## [testing-fab](./src/lib/testing-fab/testing-fab.component.ts)
+
+Floating action button for non-production testing controls.
+
+```ts
+import { provideTestingFab, TestingFabComponent } from '@shiftcode/ngx-components'
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    provideTestingFab([
+      {
+        id: 'backend-env',
+        label: 'Backend Environment',
+        type: 'select-query-param',
+        queryParam: 'env',
+        options: [
+          { label: 'QA', value: 'qa' },
+          { label: 'Preview', value: 'preview' },
+        ],
+      },
+    ]),
+  ],
+})
+```
+
+Add `<sc-testing-fab />` once in a root-level template where it should be available.

--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/ngx-components",
-  "version": "15.2.0",
+  "version": "15.2.1-pr87.0",
   "repository": "https://github.com/shiftcode/sc-ng-commons-public",
   "license": "MIT",
   "author": "shiftcode GmbH <team@shiftcode.ch>",

--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/ngx-components",
-  "version": "15.3.0-pr87.7",
+  "version": "15.3.0-pr87.8",
   "repository": "https://github.com/shiftcode/sc-ng-commons-public",
   "license": "MIT",
   "author": "shiftcode GmbH <team@shiftcode.ch>",

--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/ngx-components",
-  "version": "15.3.0-pr87.5",
+  "version": "15.3.0-pr87.6",
   "repository": "https://github.com/shiftcode/sc-ng-commons-public",
   "license": "MIT",
   "author": "shiftcode GmbH <team@shiftcode.ch>",

--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/ngx-components",
-  "version": "15.3.0-pr87.6",
+  "version": "15.3.0-pr87.7",
   "repository": "https://github.com/shiftcode/sc-ng-commons-public",
   "license": "MIT",
   "author": "shiftcode GmbH <team@shiftcode.ch>",

--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/ngx-components",
-  "version": "15.2.1-pr87.0",
+  "version": "15.3.0-pr87.0",
   "repository": "https://github.com/shiftcode/sc-ng-commons-public",
   "license": "MIT",
   "author": "shiftcode GmbH <team@shiftcode.ch>",

--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/ngx-components",
-  "version": "15.3.0-pr87.1",
+  "version": "15.3.0-pr87.2",
   "repository": "https://github.com/shiftcode/sc-ng-commons-public",
   "license": "MIT",
   "author": "shiftcode GmbH <team@shiftcode.ch>",

--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/ngx-components",
-  "version": "15.3.0-pr87.0",
+  "version": "15.3.0-pr87.1",
   "repository": "https://github.com/shiftcode/sc-ng-commons-public",
   "license": "MIT",
   "author": "shiftcode GmbH <team@shiftcode.ch>",

--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -18,6 +18,7 @@
     "@angular/router": "^21.0.0",
     "@shiftcode/logger": "^5.0.0",
     "@shiftcode/ngx-core": "^15.0.0 || ^15.3.0-pr87",
+    "@shiftcode/utilities": "^5.0.0",
     "rxjs": "^6.5.3 || ^7.4.0"
   },
   "engines": {

--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -17,7 +17,7 @@
     "@angular/forms": "^21.0.0",
     "@angular/router": "^21.0.0",
     "@shiftcode/logger": "^5.0.0",
-    "@shiftcode/ngx-core": "^15.0.0 || ^15.0.0-pr7",
+    "@shiftcode/ngx-core": "^15.0.0 || ^15.3.0-pr87",
     "rxjs": "^6.5.3 || ^7.4.0"
   },
   "engines": {

--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/ngx-components",
-  "version": "15.3.0-pr87.3",
+  "version": "15.3.0-pr87.4",
   "repository": "https://github.com/shiftcode/sc-ng-commons-public",
   "license": "MIT",
   "author": "shiftcode GmbH <team@shiftcode.ch>",

--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/ngx-components",
-  "version": "15.3.0-pr87.2",
+  "version": "15.3.0-pr87.3",
   "repository": "https://github.com/shiftcode/sc-ng-commons-public",
   "license": "MIT",
   "author": "shiftcode GmbH <team@shiftcode.ch>",

--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/ngx-components",
-  "version": "15.3.0-pr87.4",
+  "version": "15.3.0-pr87.5",
   "repository": "https://github.com/shiftcode/sc-ng-commons-public",
   "license": "MIT",
   "author": "shiftcode GmbH <team@shiftcode.ch>",

--- a/libs/components/src/lib/testing-fab/initialize-testing-fab.spec.ts
+++ b/libs/components/src/lib/testing-fab/initialize-testing-fab.spec.ts
@@ -1,0 +1,30 @@
+import { DOCUMENT } from '@angular/core'
+import { TestBed } from '@angular/core/testing'
+import { provideRouter } from '@angular/router'
+import { LocalStorage } from '@shiftcode/ngx-core'
+import { describe, expect, test, vi } from 'vitest'
+
+import initializeTestingFab from './initialize-testing-fab'
+import { TESTING_FAB_WIDGETS } from './testing-fab-config.token'
+
+describe('initializeTestingFab', () => {
+  test('creates the host element', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        { provide: TESTING_FAB_WIDGETS, useValue: [] },
+        {
+          provide: LocalStorage,
+          useValue: {
+            getItem: vi.fn().mockReturnValue(null),
+            setItem: vi.fn(),
+          } as unknown as LocalStorage,
+        },
+      ],
+    })
+
+    TestBed.runInInjectionContext(initializeTestingFab)
+
+    expect(TestBed.inject(DOCUMENT).querySelector('sc-testing-fab')).not.toBeNull()
+  })
+})

--- a/libs/components/src/lib/testing-fab/initialize-testing-fab.spec.ts
+++ b/libs/components/src/lib/testing-fab/initialize-testing-fab.spec.ts
@@ -25,6 +25,8 @@ describe('initializeTestingFab', () => {
 
     TestBed.runInInjectionContext(initializeTestingFab)
 
-    expect(TestBed.inject(DOCUMENT).querySelector('sc-testing-fab')).not.toBeNull()
+    const host = TestBed.inject(DOCUMENT).querySelector('sc-testing-fab')
+    expect(host).not.toBeNull()
+    expect(host!.firstChild).toBeDefined()
   })
 })

--- a/libs/components/src/lib/testing-fab/initialize-testing-fab.ts
+++ b/libs/components/src/lib/testing-fab/initialize-testing-fab.ts
@@ -1,0 +1,24 @@
+import { DOCUMENT } from '@angular/common'
+import { ApplicationRef, assertInInjectionContext, createComponent, EnvironmentInjector, inject } from '@angular/core'
+
+import { TestingFabComponent } from './testing-fab.component'
+
+/**
+ * Initializes the testing FAB by creating and attaching the TestingFabComponent to the document body.
+ * needs to be run in the injection context.
+ */
+export default function initializeTestingFab() {
+  assertInInjectionContext(initializeTestingFab)
+  const doc = inject(DOCUMENT)
+  const appRef = inject(ApplicationRef)
+  const environmentInjector = inject(EnvironmentInjector)
+
+  const host = doc.createElement('sc-testing-fab')
+  const cmpRef = createComponent(TestingFabComponent, {
+    hostElement: host,
+    environmentInjector,
+  })
+
+  appRef.attachView(cmpRef.hostView)
+  doc.body.appendChild(host)
+}

--- a/libs/components/src/lib/testing-fab/initialize-testing-fab.ts
+++ b/libs/components/src/lib/testing-fab/initialize-testing-fab.ts
@@ -1,5 +1,12 @@
 import { DOCUMENT } from '@angular/common'
-import { ApplicationRef, assertInInjectionContext, createComponent, EnvironmentInjector, inject } from '@angular/core'
+import {
+  ApplicationRef,
+  assertInInjectionContext,
+  createComponent,
+  DestroyRef,
+  EnvironmentInjector,
+  inject,
+} from '@angular/core'
 
 import { TestingFabComponent } from './testing-fab.component'
 
@@ -12,6 +19,7 @@ export default function initializeTestingFab() {
   const doc = inject(DOCUMENT)
   const appRef = inject(ApplicationRef)
   const environmentInjector = inject(EnvironmentInjector)
+  const destroyRef = inject(DestroyRef)
 
   const host = doc.createElement('sc-testing-fab')
   const cmpRef = createComponent(TestingFabComponent, {
@@ -21,4 +29,10 @@ export default function initializeTestingFab() {
 
   appRef.attachView(cmpRef.hostView)
   doc.body.appendChild(host)
+
+  destroyRef.onDestroy(() => {
+    appRef.detachView(cmpRef.hostView)
+    cmpRef.destroy()
+    host.remove()
+  })
 }

--- a/libs/components/src/lib/testing-fab/provide-testing-fab.spec.ts
+++ b/libs/components/src/lib/testing-fab/provide-testing-fab.spec.ts
@@ -1,0 +1,63 @@
+import { EnvironmentProviders } from '@angular/core'
+import { TestBed } from '@angular/core/testing'
+import { DefaultUrlSerializer, Router } from '@angular/router'
+import { LocalStorage } from '@shiftcode/ngx-core'
+import { NEVER } from 'rxjs'
+import { describe, expect, test, vi } from 'vitest'
+
+import { provideTestingFab } from './provide-testing-fab'
+import { TESTING_FAB_WIDGETS } from './testing-fab-config.token'
+import { TestingFabWidget } from './testing-fab-widget.type'
+
+function setup(testingFabProviders: EnvironmentProviders) {
+  const serializer = new DefaultUrlSerializer()
+
+  function createRouterMock(): Router {
+    return {
+      events: NEVER,
+      url: '/',
+      parseUrl: vi.fn<typeof serializer.parse>((value) => serializer.parse(value)),
+      navigate: vi.fn().mockResolvedValue(true),
+    } as unknown as Router
+  }
+
+  function createLocalStorageMock(): LocalStorage {
+    return {
+      persistent: true,
+      observe: vi.fn(),
+      setItem: vi.fn(),
+      getItem: vi.fn().mockReturnValue(null),
+      delete: vi.fn(),
+      clear: vi.fn(),
+      keys: vi.fn().mockReturnValue([]),
+    } as unknown as LocalStorage
+  }
+
+  TestBed.configureTestingModule({
+    providers: [
+      { provide: Router, useValue: createRouterMock() },
+      { provide: LocalStorage, useValue: createLocalStorageMock() },
+      testingFabProviders,
+    ],
+  })
+}
+
+describe('provideTestingFab', () => {
+  test('supports static widgets config and renders the testing fab', () => {
+    const widgets: readonly TestingFabWidget[] = [{ id: 'a1', label: 'Action', type: 'action', action: vi.fn() }]
+
+    setup(provideTestingFab(widgets))
+
+    expect(TestBed.inject(TESTING_FAB_WIDGETS)).toEqual(widgets)
+  })
+
+  test('supports factory widgets config', () => {
+    const widgets: readonly TestingFabWidget[] = [{ id: 'a1', label: 'Action', type: 'action', action: vi.fn() }]
+    const factory = vi.fn(() => widgets)
+
+    setup(provideTestingFab(factory))
+
+    expect(TestBed.inject(TESTING_FAB_WIDGETS)).toEqual(widgets)
+    expect(factory).toHaveBeenCalled()
+  })
+})

--- a/libs/components/src/lib/testing-fab/provide-testing-fab.spec.ts
+++ b/libs/components/src/lib/testing-fab/provide-testing-fab.spec.ts
@@ -49,7 +49,9 @@ function setup(testingFabProviders: EnvironmentProviders) {
 
 describe('provideTestingFab', () => {
   test('supports static widgets config and renders the testing fab', async () => {
-    const widgets: readonly TestingFabWidget[] = [{ id: 'a1', label: 'Action', type: 'action', action: vi.fn() }]
+    const widgets: readonly TestingFabWidget[] = [
+      { id: 'a1', label: 'Action', type: 'toggle-query-param', queryParam: 'flag' },
+    ]
 
     setup(provideTestingFab(widgets))
 
@@ -59,7 +61,9 @@ describe('provideTestingFab', () => {
   })
 
   test('supports factory widgets config', async () => {
-    const widgets: readonly TestingFabWidget[] = [{ id: 'a1', label: 'Action', type: 'action', action: vi.fn() }]
+    const widgets: readonly TestingFabWidget[] = [
+      { id: 'a1', label: 'Action', type: 'toggle-query-param', queryParam: 'flag' },
+    ]
     const factory = vi.fn(() => widgets)
 
     setup(provideTestingFab(factory))

--- a/libs/components/src/lib/testing-fab/provide-testing-fab.spec.ts
+++ b/libs/components/src/lib/testing-fab/provide-testing-fab.spec.ts
@@ -3,11 +3,16 @@ import { TestBed } from '@angular/core/testing'
 import { DefaultUrlSerializer, Router } from '@angular/router'
 import { LocalStorage } from '@shiftcode/ngx-core'
 import { NEVER } from 'rxjs'
-import { describe, expect, test, vi } from 'vitest'
+import { beforeEach, describe, expect, Mock, test, vi } from 'vitest'
 
 import { provideTestingFab } from './provide-testing-fab'
 import { TESTING_FAB_WIDGETS } from './testing-fab-config.token'
 import { TestingFabWidget } from './testing-fab-widget.type'
+
+let initFn: Mock
+beforeEach(async () => {
+  initFn = vi.spyOn(await import('./initialize-testing-fab'), 'default')
+})
 
 function setup(testingFabProviders: EnvironmentProviders) {
   const serializer = new DefaultUrlSerializer()
@@ -43,15 +48,17 @@ function setup(testingFabProviders: EnvironmentProviders) {
 }
 
 describe('provideTestingFab', () => {
-  test('supports static widgets config and renders the testing fab', () => {
+  test('supports static widgets config and renders the testing fab', async () => {
     const widgets: readonly TestingFabWidget[] = [{ id: 'a1', label: 'Action', type: 'action', action: vi.fn() }]
 
     setup(provideTestingFab(widgets))
 
     expect(TestBed.inject(TESTING_FAB_WIDGETS)).toEqual(widgets)
+
+    await expect.poll(() => initFn).toHaveBeenCalledTimes(1)
   })
 
-  test('supports factory widgets config', () => {
+  test('supports factory widgets config', async () => {
     const widgets: readonly TestingFabWidget[] = [{ id: 'a1', label: 'Action', type: 'action', action: vi.fn() }]
     const factory = vi.fn(() => widgets)
 
@@ -59,5 +66,7 @@ describe('provideTestingFab', () => {
 
     expect(TestBed.inject(TESTING_FAB_WIDGETS)).toEqual(widgets)
     expect(factory).toHaveBeenCalled()
+
+    await expect.poll(() => initFn).toHaveBeenCalledTimes(1)
   })
 })

--- a/libs/components/src/lib/testing-fab/provide-testing-fab.ts
+++ b/libs/components/src/lib/testing-fab/provide-testing-fab.ts
@@ -15,8 +15,8 @@ type ValueOrFactory<T> = T | (() => T)
 
 /**
  * Provides the testing FAB with the given widgets and enables it based on the provided flag.
- * if not flag is provided, the FAB will be enabled by default.
- * Will only initialize the FAB in the browser platform.
+ * If no `enabled` flag is provided, the FAB will be enabled by default.
+ * Will only initialize the FAB on the browser platform.
  */
 export function provideTestingFab(
   widgets: ValueOrFactory<readonly TestingFabWidget[]>,

--- a/libs/components/src/lib/testing-fab/provide-testing-fab.ts
+++ b/libs/components/src/lib/testing-fab/provide-testing-fab.ts
@@ -14,7 +14,7 @@ import { TestingFabWidget } from './testing-fab-widget.type'
 type ValueOrFactory<T> = T | (() => T)
 
 /**
- * Provides the testing FAB with the given widgets and enables it based on the provided flag.
+ * Provides the testing FAB asynchronously with the given widgets and enables it based on the provided flag.
  * If no `enabled` flag is provided, the FAB will be enabled by default.
  * Will only initialize the FAB on the browser platform.
  */
@@ -33,13 +33,11 @@ export function provideTestingFab(
       const isEnabled = typeof enabled === 'function' ? enabled() : enabled
 
       if (isPlatformBrowser(platform) && isEnabled) {
-        void import('./initialize-testing-fab')
-          .then((module) => module.default)
-          .then((initFn) => {
-            if (!envInjector.destroyed) {
-              runInInjectionContext(envInjector, initFn)
-            }
-          })
+        void import('./initialize-testing-fab').then((module) => {
+          if (!envInjector.destroyed) {
+            runInInjectionContext(envInjector, module.default)
+          }
+        })
       }
     }),
   ])

--- a/libs/components/src/lib/testing-fab/provide-testing-fab.ts
+++ b/libs/components/src/lib/testing-fab/provide-testing-fab.ts
@@ -35,7 +35,11 @@ export function provideTestingFab(
       if (isPlatformBrowser(platform) && isEnabled) {
         void import('./initialize-testing-fab')
           .then((module) => module.default)
-          .then((initFn) => runInInjectionContext(envInjector, initFn))
+          .then((initFn) => {
+            if (!envInjector.destroyed) {
+              runInInjectionContext(envInjector, initFn)
+            }
+          })
       }
     }),
   ])

--- a/libs/components/src/lib/testing-fab/provide-testing-fab.ts
+++ b/libs/components/src/lib/testing-fab/provide-testing-fab.ts
@@ -1,0 +1,42 @@
+import { isPlatformBrowser } from '@angular/common'
+import {
+  EnvironmentInjector,
+  inject,
+  makeEnvironmentProviders,
+  PLATFORM_ID,
+  provideEnvironmentInitializer,
+  runInInjectionContext,
+} from '@angular/core'
+
+import { TESTING_FAB_WIDGETS } from './testing-fab-config.token'
+import { TestingFabWidget } from './testing-fab-widget.type'
+
+type ValueOrFactory<T> = T | (() => T)
+
+/**
+ * Provides the testing FAB with the given widgets and enables it based on the provided flag.
+ * if not flag is provided, the FAB will be enabled by default.
+ * Will only initialize the FAB in the browser platform.
+ */
+export function provideTestingFab(
+  widgets: ValueOrFactory<readonly TestingFabWidget[]>,
+  enabled: ValueOrFactory<boolean> = true,
+) {
+  return makeEnvironmentProviders([
+    {
+      provide: TESTING_FAB_WIDGETS,
+      ...(typeof widgets === 'function' ? { useFactory: widgets } : { useValue: widgets }),
+    },
+    provideEnvironmentInitializer(() => {
+      const envInjector = inject(EnvironmentInjector)
+      const platform = inject(PLATFORM_ID)
+      const isEnabled = typeof enabled === 'function' ? enabled() : enabled
+
+      if (isPlatformBrowser(platform) && isEnabled) {
+        void import('./initialize-testing-fab')
+          .then((module) => module.default)
+          .then((initFn) => runInInjectionContext(envInjector, initFn))
+      }
+    }),
+  ])
+}

--- a/libs/components/src/lib/testing-fab/testing-fab-config.token.ts
+++ b/libs/components/src/lib/testing-fab/testing-fab-config.token.ts
@@ -1,0 +1,5 @@
+import { InjectionToken } from '@angular/core'
+
+import { TestingFabWidget } from './testing-fab-widget.type'
+
+export const TESTING_FAB_WIDGETS = new InjectionToken<readonly TestingFabWidget[]>('')

--- a/libs/components/src/lib/testing-fab/testing-fab-config.token.ts
+++ b/libs/components/src/lib/testing-fab/testing-fab-config.token.ts
@@ -2,4 +2,4 @@ import { InjectionToken } from '@angular/core'
 
 import { TestingFabWidget } from './testing-fab-widget.type'
 
-export const TESTING_FAB_WIDGETS = new InjectionToken<readonly TestingFabWidget[]>('')
+export const TESTING_FAB_WIDGETS = new InjectionToken<readonly TestingFabWidget[]>('TESTING_FAB_WIDGETS')

--- a/libs/components/src/lib/testing-fab/testing-fab-widget.type.ts
+++ b/libs/components/src/lib/testing-fab/testing-fab-widget.type.ts
@@ -21,6 +21,7 @@ export interface TestingFabSelectQueryParamWidget extends TestingFabWidgetBase {
   queryParam: string
   options: readonly TestingFabSelectOption[]
   hardReload?: boolean
+  skipEmptyOption?: boolean
 }
 
 export interface TestingFabSelectOption {

--- a/libs/components/src/lib/testing-fab/testing-fab-widget.type.ts
+++ b/libs/components/src/lib/testing-fab/testing-fab-widget.type.ts
@@ -1,0 +1,34 @@
+import { Type } from '@angular/core'
+
+export type TestingFabWidget =
+  | TestingFabActionWidget
+  | TestingFabSelectQueryParamWidget
+  | TestingFabCustomComponentWidget
+
+interface TestingFabWidgetBase {
+  id: string
+  label: string
+}
+
+export interface TestingFabActionWidget extends TestingFabWidgetBase {
+  type: 'action'
+  buttonLabel?: string
+  action: () => void
+}
+
+export interface TestingFabSelectQueryParamWidget extends TestingFabWidgetBase {
+  type: 'select-query-param'
+  queryParam: string
+  options: readonly TestingFabSelectOption[]
+  hardReload?: boolean
+}
+
+export interface TestingFabSelectOption {
+  value: string
+  label: string
+}
+
+export interface TestingFabCustomComponentWidget extends TestingFabWidgetBase {
+  type: 'custom-component'
+  component: Type<unknown>
+}

--- a/libs/components/src/lib/testing-fab/testing-fab-widget.type.ts
+++ b/libs/components/src/lib/testing-fab/testing-fab-widget.type.ts
@@ -1,19 +1,14 @@
 import { Type } from '@angular/core'
 
 export type TestingFabWidget =
-  | TestingFabActionWidget
   | TestingFabSelectQueryParamWidget
+  | TestingFabToggleQueryParamWidget
   | TestingFabCustomComponentWidget
 
 interface TestingFabWidgetBase {
+  type: 'select-query-param' | 'toggle-query-param' | 'custom-component'
   id: string
   label: string
-}
-
-export interface TestingFabActionWidget extends TestingFabWidgetBase {
-  type: 'action'
-  buttonLabel?: string
-  action: () => void
 }
 
 export interface TestingFabSelectQueryParamWidget extends TestingFabWidgetBase {
@@ -22,6 +17,12 @@ export interface TestingFabSelectQueryParamWidget extends TestingFabWidgetBase {
   options: readonly TestingFabSelectOption[]
   hardReload?: boolean
   skipEmptyOption?: boolean
+}
+
+export interface TestingFabToggleQueryParamWidget extends TestingFabWidgetBase {
+  type: 'toggle-query-param'
+  queryParam: string
+  hardReload?: boolean
 }
 
 export interface TestingFabSelectOption {

--- a/libs/components/src/lib/testing-fab/testing-fab-widget.type.ts
+++ b/libs/components/src/lib/testing-fab/testing-fab-widget.type.ts
@@ -22,6 +22,7 @@ export interface TestingFabSelectQueryParamWidget extends TestingFabWidgetBase {
 export interface TestingFabToggleQueryParamWidget extends TestingFabWidgetBase {
   type: 'toggle-query-param'
   queryParam: string
+  title?: string
   hardReload?: boolean
 }
 

--- a/libs/components/src/lib/testing-fab/testing-fab.component.html
+++ b/libs/components/src/lib/testing-fab/testing-fab.component.html
@@ -15,16 +15,10 @@
   @for (widget of widgets; track widget.id) {
     @let widgetId = 'sc-testing-fab-' + widget.id;
     <div class="sc-testing-fab__widget">
-      <label [attr.for]="widgetId" class="sc-testing-fab__widget-label">{{ widget.label }}</label>
-
+      @let currentValue = qpWidgetValues()[widget.id];
       @switch (widget.type) {
-        @case ('action') {
-          <button type="button" [id]="widgetId" class="sc-testing-fab__action" (click)="widget.action()">
-            {{ widget.buttonLabel ?? widget.label }}
-          </button>
-        }
         @case ('select-query-param') {
-          @let currentValue = qpWidgetValues()[widget.id];
+          <label [attr.for]="widgetId" class="sc-testing-fab__widget-label">{{ widget.label }}</label>
           <select
             [id]="widgetId"
             class="sc-testing-fab__select"
@@ -39,7 +33,21 @@
             }
           </select>
         }
+        @case ('toggle-query-param') {
+          <span class="sc-testing-fab__widget-label">{{ widget.label }}</span>
+
+          <label [attr.for]="widgetId" class="sc-testing-fab__checkbox">
+            <input
+              type="checkbox"
+              [id]="widgetId"
+              [checked]="currentValue"
+              (change)="setToggleQueryParam(widget, $event)"
+            />
+            <span [innerText]="currentValue ? 'Enabled' : 'Disabled'"></span>
+          </label>
+        }
         @case ('custom-component') {
+          <span class="sc-testing-fab__widget-label">{{ widget.label }}</span>
           <ng-container [ngComponentOutlet]="widget.component" />
         }
       }

--- a/libs/components/src/lib/testing-fab/testing-fab.component.html
+++ b/libs/components/src/lib/testing-fab/testing-fab.component.html
@@ -1,0 +1,46 @@
+@let panelId = 'sc-testing-fab-panel';
+<button
+  type="button"
+  class="sc-testing-fab__trigger"
+  aria-label="Toggle testing controls"
+  [attr.popovertarget]="panelId"
+  (pointerdown)="onTriggerPointerDown($event)"
+  (pointermove)="onTriggerPointerMove($event)"
+  (pointerup)="onTriggerPointerUp($event)"
+  (pointercancel)="onTriggerPointerCancel($event)"
+  (click)="onTriggerClick($event)"
+></button>
+
+<section [id]="panelId" popover="auto" class="sc-testing-fab__panel">
+  @for (widget of widgets; track widget.id) {
+    @let widgetId = 'sc-testing-fab-' + widget.id;
+    <div class="sc-testing-fab__widget">
+      <label [attr.for]="widgetId" class="sc-testing-fab__widget-label">{{ widget.label }}</label>
+
+      @switch (widget.type) {
+        @case ('action') {
+          <button type="button" [id]="widgetId" class="sc-testing-fab__action" (click)="widget.action()">
+            {{ widget.buttonLabel ?? widget.label }}
+          </button>
+        }
+        @case ('select-query-param') {
+          @let currentValue = qpWidgetValues()[widget.id];
+          <select
+            [id]="widgetId"
+            class="sc-testing-fab__select"
+            [value]="currentValue"
+            (change)="setQueryParam(widget, $event)"
+          >
+            <option value="">–</option>
+            @for (option of widget.options; track option.value) {
+              <option [value]="option.value" [selected]="option.value === currentValue">{{ option.label }}</option>
+            }
+          </select>
+        }
+        @case ('custom-component') {
+          <ng-container [ngComponentOutlet]="widget.component" />
+        }
+      }
+    </div>
+  }
+</section>

--- a/libs/components/src/lib/testing-fab/testing-fab.component.html
+++ b/libs/components/src/lib/testing-fab/testing-fab.component.html
@@ -34,8 +34,9 @@
           </select>
         }
         @case ('toggle-query-param') {
-          <span class="sc-testing-fab__widget-label">{{ widget.label }}</span>
-
+          @if (widget.title) {
+            <span class="sc-testing-fab__widget-label">{{ widget.title }}</span>
+          }
           <label [attr.for]="widgetId" class="sc-testing-fab__checkbox">
             <input
               type="checkbox"
@@ -43,7 +44,7 @@
               [checked]="currentValue"
               (change)="setToggleQueryParam(widget, $event)"
             />
-            <span [innerText]="currentValue ? 'Enabled' : 'Disabled'"></span>
+            <span>{{ widget.label }}</span>
           </label>
         }
         @case ('custom-component') {

--- a/libs/components/src/lib/testing-fab/testing-fab.component.html
+++ b/libs/components/src/lib/testing-fab/testing-fab.component.html
@@ -31,7 +31,9 @@
             [value]="currentValue"
             (change)="setQueryParam(widget, $event)"
           >
-            <option value="">–</option>
+            @if (!widget.skipEmptyOption) {
+              <option value="">–</option>
+            }
             @for (option of widget.options; track option.value) {
               <option [value]="option.value" [selected]="option.value === currentValue">{{ option.label }}</option>
             }

--- a/libs/components/src/lib/testing-fab/testing-fab.component.scss
+++ b/libs/components/src/lib/testing-fab/testing-fab.component.scss
@@ -1,5 +1,5 @@
 $defaultMargin: 16px;
-$defaultFabIcon: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PCFET0NUWVBFIHN2ZyBQVUJMSUMgIi0vL1czQy8vRFREIFNWRyAxLjEvL0VOIiAiaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkIj48c3ZnIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIHZpZXdCb3g9IjAgMCA0NDIgNTc5IiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHhtbDpzcGFjZT0icHJlc2VydmUiIHhtbG5zOnNlcmlmPSJodHRwOi8vd3d3LnNlcmlmLmNvbS8iIHN0eWxlPSJmaWxsLXJ1bGU6ZXZlbm9kZDtjbGlwLXJ1bGU6ZXZlbm9kZDtzdHJva2UtbGluZWpvaW46cm91bmQ7c3Ryb2tlLW1pdGVybGltaXQ6MjsiPjxwYXRoIGQ9Ik0wLDE5Mi45MTdsMTkyLjkxNywtMTkyLjkxN2w5Ni4yNSwwbC0xOTIuOTE3LDE5Mi45MTdsMTkyLjkxNywxOTIuNWwtMTkyLjkxNywxOTIuOTE2bC05Ni4yNSwwbDE5Mi45MTcsLTE5Mi45MTZsLTE5Mi45MTcsLTE5Mi41WiIvPjxwYXRoIGQ9Ik0xNTIuNSwxOTIuOTE3bDE5Mi41LC0xOTIuOTE3bDk2LjY2NywwbC0xOTIuOTE3LDE5Mi45MTdsMTkyLjkxNywxOTIuNWwtOTYuNjY3LDBsLTE5Mi41LC0xOTIuNVoiLz48L3N2Zz4=');
+$defaultFabIcon: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+Cjxzdmcgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDQ0MiA1NzkiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSIgeG1sbnM6c2VyaWY9Imh0dHA6Ly93d3cuc2VyaWYuY29tLyIgc3R5bGU9ImZpbGwtcnVsZTpldmVub2RkO2NsaXAtcnVsZTpldmVub2RkO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2UtbWl0ZXJsaW1pdDoyOyI+CiAgICA8cGF0aCBkPSJNMjg5LjE2NywwTDE5Mi45MTcsMEwxOTIuOTE3LDk2LjI1TDI4OS4xNjcsMFoiIHN0eWxlPSJmaWxsOiNlMDIwMmI7ZmlsbC1ydWxlOm5vbnplcm87Ii8+CiAgICA8cGF0aCBkPSJNOTYuMjUsOTYuMjVMMTkyLjkxNyw5Ni4yNUwxOTIuOTE3LDBMOTYuMjUsOTYuMjVaIiBzdHlsZT0iZmlsbDojYzYxYzI2O2ZpbGwtcnVsZTpub256ZXJvOyIvPgogICAgPHBhdGggZD0iTTk2LjI1LDE5Mi45MTdMOTYuMjUsOTYuMjVMMTkyLjkxNyw5Ni4yNUw5Ni4yNSwxOTIuOTE3WiIgc3R5bGU9ImZpbGw6I2UwNDgxZTtmaWxsLXJ1bGU6bm9uemVybzsiLz4KICAgIDxwYXRoIGQ9Ik05Ni4yNSw5Ni4yNUw5Ni4yNSwxOTIuOTE3TDAsMTkyLjkxN0w5Ni4yNSw5Ni4yNVoiIHN0eWxlPSJmaWxsOiNiZDNjMTk7ZmlsbC1ydWxlOm5vbnplcm87Ii8+CiAgICA8cGF0aCBkPSJNMTkyLjkxNywyODkuMTY3TDE5Mi45MTcsMzg1LjQxN0wyODkuMTY3LDM4NS40MTdMMTkyLjkxNywyODkuMTY3WiIgc3R5bGU9ImZpbGw6I2UzYTExMjtmaWxsLXJ1bGU6bm9uemVybzsiLz4KICAgIDxwYXRoIGQ9Ik0xOTIuOTE3LDM4NS40MTdMMTkyLjkxNywyODkuMTY3TDk2LjI1LDI4OS4xNjdMMTkyLjkxNywzODUuNDE3WiIgc3R5bGU9ImZpbGw6I2ZmYjUxNDtmaWxsLXJ1bGU6bm9uemVybzsiLz4KICAgIDxwYXRoIGQ9Ik05Ni4yNSwxOTIuOTE3TDk2LjI1LDI4OS4xNjdMMTkyLjkxNywyODkuMTY3TDk2LjI1LDE5Mi45MTdaIiBzdHlsZT0iZmlsbDojZWI3MDFkO2ZpbGwtcnVsZTpub256ZXJvOyIvPgogICAgPHBhdGggZD0iTTk2LjI1LDI4OS4xNjdMOTYuMjUsMTkyLjkxN0wwLDE5Mi45MTdMOTYuMjUsMjg5LjE2N1oiIHN0eWxlPSJmaWxsOiNmZjdhMjA7ZmlsbC1ydWxlOm5vbnplcm87Ii8+CiAgICA8cGF0aCBkPSJNMTkyLjkxNyw0ODIuMDgzTDE5Mi45MTcsMzg1LjQxN0wyODkuMTY3LDM4NS40MTdMMTkyLjkxNyw0ODIuMDgzWiIgc3R5bGU9ImZpbGw6I2YyZWIzNztmaWxsLXJ1bGU6bm9uemVybzsiLz4KICAgIDxwYXRoIGQ9Ik0xOTIuOTE3LDM4NS40MTdMMTkyLjkxNyw0ODIuMDgzTDk2LjI1LDQ4Mi4wODNMMTkyLjkxNywzODUuNDE3WiIgc3R5bGU9ImZpbGw6I2UzZGMzNDtmaWxsLXJ1bGU6bm9uemVybzsiLz4KICAgIDxwYXRoIGQ9Ik05Ni4yNSw1NzguMzMzTDk2LjI1LDQ4Mi4wODNMMTkyLjkxNyw0ODIuMDgzTDk2LjI1LDU3OC4zMzNaIiBzdHlsZT0iZmlsbDojYjJlMjU1O2ZpbGwtcnVsZTpub256ZXJvOyIvPgogICAgPHBhdGggZD0iTTk2LjI1LDQ4Mi4wODNMOTYuMjUsNTc4LjMzM0wwLDU3OC4zMzNMOTYuMjUsNDgyLjA4M1oiIHN0eWxlPSJmaWxsOiNhM2NmNGU7ZmlsbC1ydWxlOm5vbnplcm87Ii8+CiAgICA8cGF0aCBkPSJNMzQ1LDk2LjI1TDM0NSwwTDQ0MS42NjcsMEwzNDUsOTYuMjVaIiBzdHlsZT0iZmlsbDojNjNmMWZmO2ZpbGwtcnVsZTpub256ZXJvOyIvPgogICAgPHBhdGggZD0iTTM0NSwwTDM0NSw5Ni4yNUwyNDguNzUsOTYuMjVMMzQ1LDBaIiBzdHlsZT0iZmlsbDojNGZjMWNjO2ZpbGwtcnVsZTpub256ZXJvOyIvPgogICAgPHBhdGggZD0iTTI0OC43NSwxOTIuOTE3TDI0OC43NSw5Ni4yNUwzNDUsOTYuMjVMMjQ4Ljc1LDE5Mi45MTdaIiBzdHlsZT0iZmlsbDojNDNhNmIwO2ZpbGwtcnVsZTpub256ZXJvOyIvPgogICAgPHBhdGggZD0iTTI0OC43NSw5Ni4yNUwyNDguNzUsMTkyLjkxN0wxNTIuNSwxOTIuOTE3TDI0OC43NSw5Ni4yNVoiIHN0eWxlPSJmaWxsOiMzNTgyOGE7ZmlsbC1ydWxlOm5vbnplcm87Ii8+CiAgICA8cGF0aCBkPSJNMzQ1LDI4OS4xNjdMMzQ1LDM4NS40MTdMNDQxLjY2NywzODUuNDE3TDM0NSwyODkuMTY3WiIgc3R5bGU9ImZpbGw6IzI1Njk2MDtmaWxsLXJ1bGU6bm9uemVybzsiLz4KICAgIDxwYXRoIGQ9Ik0zNDUsMzg1LjQxN0wzNDUsMjg5LjE2N0wyNDguNzUsMjg5LjE2N0wzNDUsMzg1LjQxN1oiIHN0eWxlPSJmaWxsOiMzOWE0OTY7ZmlsbC1ydWxlOm5vbnplcm87Ii8+CiAgICA8cGF0aCBkPSJNMjQ4Ljc1LDE5Mi45MTdMMjQ4Ljc1LDI4OS4xNjdMMzQ1LDI4OS4xNjdMMjQ4Ljc1LDE5Mi45MTdaIiBzdHlsZT0iZmlsbDojMmM3ZDczO2ZpbGwtcnVsZTpub256ZXJvOyIvPgogICAgPHBhdGggZD0iTTI0OC43NSwyODkuMTY3TDI0OC43NSwxOTIuOTE3TDE1Mi41LDE5Mi45MTdMMjQ4Ljc1LDI4OS4xNjdaIiBzdHlsZT0iZmlsbDojMzU5NzhhO2ZpbGwtcnVsZTpub256ZXJvOyIvPgo8L3N2Zz4K');
 $defaultFabRadius: 50%;
 $defaultFabSize: 48px;
 $defaultFabBackground: #fff;
@@ -8,10 +8,15 @@ $defaultFabShadow: 0 0 8px rgb(0 0 0 / 30%);
 $defaultFabShadowHover: 0 0 32px rgb(0 0 0 / 40%);
 
 :host {
+  display: block;
   position: fixed;
   inset: auto 0 0 auto;
   z-index: 2147483647;
   margin: var(--sc-testing-fab-margin, #{$defaultMargin});
+
+  @media print {
+    display: none;
+  }
 }
 
 :host(.sc-testing-fab--top-left) {
@@ -56,6 +61,9 @@ $defaultFabShadowHover: 0 0 32px rgb(0 0 0 / 40%);
     background-size: contain;
     background-repeat: no-repeat;
     background-position: center;
+    // filter to make it a black silhouette.
+    filter: contrast(0) brightness(0%);
+    transition: filter 200ms ease;
   }
 
   transition:
@@ -65,6 +73,9 @@ $defaultFabShadowHover: 0 0 32px rgb(0 0 0 / 40%);
   &:is(:hover, :focus-visible) {
     background: var(--sc-testing-fab-background-hover, #{$defaultFabBackgroundHover});
     box-shadow: var(--sc-testing-fab-shadow, #{$defaultFabShadowHover});
+    &:before {
+      filter: none;
+    }
   }
 }
 
@@ -122,6 +133,7 @@ $defaultFabShadowHover: 0 0 32px rgb(0 0 0 / 40%);
   font-size: 12px;
   line-height: 1.5;
 }
+
 .sc-testing-fab__checkbox {
   display: flex;
   align-items: center;
@@ -129,6 +141,7 @@ $defaultFabShadowHover: 0 0 32px rgb(0 0 0 / 40%);
   border: 1px solid #9ca3af;
   border-radius: 3px;
   padding: 6px 8px;
+
   & > span {
     flex: 1 1 auto;
     user-select: none;

--- a/libs/components/src/lib/testing-fab/testing-fab.component.scss
+++ b/libs/components/src/lib/testing-fab/testing-fab.component.scss
@@ -120,6 +120,19 @@ $defaultFabShadowHover: 0 0 32px rgb(0 0 0 / 40%);
 .sc-testing-fab__widget-label {
   font-weight: 600;
   font-size: 12px;
+  line-height: 1.5;
+}
+.sc-testing-fab__checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid #9ca3af;
+  border-radius: 3px;
+  padding: 6px 8px;
+  & > span {
+    flex: 1 1 auto;
+    user-select: none;
+  }
 }
 
 .sc-testing-fab__select,

--- a/libs/components/src/lib/testing-fab/testing-fab.component.scss
+++ b/libs/components/src/lib/testing-fab/testing-fab.component.scss
@@ -130,6 +130,9 @@ $defaultFabShadowHover: 0 0 32px rgb(0 0 0 / 40%);
   padding: 6px 8px;
   background: #fff;
   color: inherit;
+  font-size: 16px;
+  line-height: 1;
+  min-height: 0;
 }
 
 .sc-testing-fab__action {

--- a/libs/components/src/lib/testing-fab/testing-fab.component.scss
+++ b/libs/components/src/lib/testing-fab/testing-fab.component.scss
@@ -1,0 +1,137 @@
+$defaultMargin: 16px;
+$defaultFabIcon: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PCFET0NUWVBFIHN2ZyBQVUJMSUMgIi0vL1czQy8vRFREIFNWRyAxLjEvL0VOIiAiaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkIj48c3ZnIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIHZpZXdCb3g9IjAgMCA0NDIgNTc5IiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHhtbDpzcGFjZT0icHJlc2VydmUiIHhtbG5zOnNlcmlmPSJodHRwOi8vd3d3LnNlcmlmLmNvbS8iIHN0eWxlPSJmaWxsLXJ1bGU6ZXZlbm9kZDtjbGlwLXJ1bGU6ZXZlbm9kZDtzdHJva2UtbGluZWpvaW46cm91bmQ7c3Ryb2tlLW1pdGVybGltaXQ6MjsiPjxwYXRoIGQ9Ik0wLDE5Mi45MTdsMTkyLjkxNywtMTkyLjkxN2w5Ni4yNSwwbC0xOTIuOTE3LDE5Mi45MTdsMTkyLjkxNywxOTIuNWwtMTkyLjkxNywxOTIuOTE2bC05Ni4yNSwwbDE5Mi45MTcsLTE5Mi45MTZsLTE5Mi45MTcsLTE5Mi41WiIvPjxwYXRoIGQ9Ik0xNTIuNSwxOTIuOTE3bDE5Mi41LC0xOTIuOTE3bDk2LjY2NywwbC0xOTIuOTE3LDE5Mi45MTdsMTkyLjkxNywxOTIuNWwtOTYuNjY3LDBsLTE5Mi41LC0xOTIuNVoiLz48L3N2Zz4=');
+$defaultFabRadius: 50%;
+$defaultFabSize: 48px;
+$defaultFabBackground: #fff;
+$defaultFabBackgroundHover: #fff;
+$defaultFabShadow: 0 0 8px rgb(0 0 0 / 30%);
+$defaultFabShadowHover: 0 0 32px rgb(0 0 0 / 40%);
+
+:host {
+  position: fixed;
+  inset: auto 0 0 auto;
+  z-index: 2147483647;
+  margin: var(--sc-testing-fab-margin, #{$defaultMargin});
+}
+
+:host(.sc-testing-fab--top-left) {
+  inset: 0 auto auto 0;
+  --sc-testing-fab-panel-transform-origin: top left;
+}
+
+:host(.sc-testing-fab--top-right) {
+  inset: 0 0 auto auto;
+  --sc-testing-fab-panel-transform-origin: top right;
+}
+
+:host(.sc-testing-fab--bottom-left) {
+  inset: auto auto 0 0;
+  --sc-testing-fab-panel-transform-origin: bottom left;
+}
+
+:host(.sc-testing-fab--bottom-right) {
+  inset: auto 0 0 auto;
+  --sc-testing-fab-panel-transform-origin: bottom right;
+}
+
+.sc-testing-fab__trigger {
+  anchor-name: --sc-testing-fab-trigger;
+  width: var(--sc-testing-fab-size, #{$defaultFabSize});
+  height: var(--sc-testing-fab-size, #{$defaultFabSize});
+  border-radius: var(--sc-testing-fab-radius, #{$defaultFabRadius});
+  border: 0;
+  background: var(--sc-testing-fab-background, #{$defaultFabBackground});
+  cursor: pointer;
+  touch-action: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--sc-testing-fab-shadow, #{$defaultFabShadow});
+
+  &:before {
+    content: '';
+    width: 50%;
+    height: 50%;
+    background-image: var(--sc-testing-fab-icon, #{$defaultFabIcon});
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+  }
+
+  transition:
+    background 140ms ease,
+    box-shadow 140ms ease;
+
+  &:is(:hover, :focus-visible) {
+    background: var(--sc-testing-fab-background-hover, #{$defaultFabBackgroundHover});
+    box-shadow: var(--sc-testing-fab-shadow, #{$defaultFabShadowHover});
+  }
+}
+
+.sc-testing-fab__panel {
+  position-anchor: --sc-testing-fab-trigger;
+  position: fixed;
+  position-area: block-start span-inline-end;
+  position-try-fallbacks:
+    block-start span-inline-start,
+    block-end span-inline-end,
+    block-end span-inline-start;
+  margin-block: var(--sc-testing-fab-margin, #{$defaultMargin});
+
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+
+  min-width: 240px;
+  max-width: min(320px, calc(100vw - 32px));
+  max-height: min(60vh, 560px);
+  overflow: auto;
+  padding: 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: #fff;
+  color: #111827;
+  box-shadow: 0 8px 24px rgb(0 0 0 / 25%);
+
+  transform-origin: var(--sc-testing-fab-panel-transform-origin);
+  transition:
+    opacity 140ms ease,
+    scale 140ms ease;
+
+  opacity: 0;
+  scale: 1 0.9;
+
+  &:popover-open {
+    opacity: 1;
+    scale: 1 1;
+
+    @starting-style {
+      opacity: 0;
+      scale: 1 0.9;
+    }
+  }
+}
+
+.sc-testing-fab__widget {
+  display: grid;
+  gap: 8px;
+}
+
+.sc-testing-fab__widget-label {
+  font-weight: 600;
+  font-size: 12px;
+}
+
+.sc-testing-fab__select,
+.sc-testing-fab__action {
+  width: 100%;
+  border: 1px solid #9ca3af;
+  border-radius: 3px;
+  padding: 6px 8px;
+  background: #fff;
+  color: inherit;
+}
+
+.sc-testing-fab__action {
+  cursor: pointer;
+}

--- a/libs/components/src/lib/testing-fab/testing-fab.component.spec.ts
+++ b/libs/components/src/lib/testing-fab/testing-fab.component.spec.ts
@@ -117,6 +117,77 @@ describe('TestingFabComponent', () => {
     })
   })
 
+  test.each([
+    ['true', true],
+    ['1', true],
+    ['', true],
+    ['false', false],
+  ])('renders toggle widget from URL query parameter (%s)', (toggleValue, expectedChecked) => {
+    const widgets: readonly TestingFabWidget[] = [
+      {
+        id: 'feature-flag',
+        label: 'Feature Flag',
+        type: 'toggle-query-param',
+        queryParam: 'feature',
+      },
+    ]
+
+    const encodedValue = encodeURIComponent(toggleValue)
+    const { fixture, routerEvents } = setup(widgets, `/?feature=${encodedValue}`)
+    routerEvents.next(new NavigationEnd(1, `/?feature=${encodedValue}`, `/?feature=${encodedValue}`))
+    fixture.detectChanges()
+
+    const checkbox = queryRequired<HTMLInputElement>(fixture, 'input[type="checkbox"]')
+    expect(checkbox.checked).toBe(expectedChecked)
+  })
+
+  test('updates query parameters when toggle widget value changes', () => {
+    const widgets: readonly TestingFabWidget[] = [
+      {
+        id: 'feature-flag',
+        label: 'Feature Flag',
+        type: 'toggle-query-param',
+        queryParam: 'feature',
+      },
+    ]
+
+    const { fixture, routerMock } = setup(widgets, '/?feature=true')
+    const checkbox = queryRequired<HTMLInputElement>(fixture, 'input[type="checkbox"]')
+
+    checkbox.checked = false
+    checkbox.dispatchEvent(new Event('change'))
+    expect(routerMock.navigate).toHaveBeenCalledWith([], {
+      queryParams: { feature: null },
+      queryParamsHandling: 'merge',
+    })
+
+    checkbox.checked = true
+    checkbox.dispatchEvent(new Event('change'))
+    expect(routerMock.navigate).toHaveBeenNthCalledWith(2, [], {
+      queryParams: { feature: 'true' },
+      queryParamsHandling: 'merge',
+    })
+  })
+
+  test('forces hard reload when configured on toggle widget', () => {
+    const widgets: readonly TestingFabWidget[] = [
+      {
+        id: 'feature-flag',
+        label: 'Feature Flag',
+        type: 'toggle-query-param',
+        queryParam: 'feature',
+        hardReload: true,
+      },
+    ]
+
+    const { fixture, routerMock } = setup(widgets, '/?feature=true')
+    const checkbox = queryRequired<HTMLInputElement>(fixture, 'input[type="checkbox"]')
+    checkbox.checked = false
+    expect(() => checkbox.dispatchEvent(new Event('change'))).not.toThrow()
+
+    expect(routerMock.navigate).not.toHaveBeenCalled()
+  })
+
   test('forces hard reload when configured on select widget', () => {
     const widgets: readonly TestingFabWidget[] = [
       {
@@ -153,24 +224,6 @@ describe('TestingFabComponent', () => {
     const { fixture } = setup(widgets)
     const customWidget = queryRequired<HTMLElement>(fixture, '[data-test-id="custom-widget"]')
     expect(customWidget).not.toBeNull()
-  })
-
-  test('runs action widgets when clicked', () => {
-    const action = vi.fn()
-    const widgets: readonly TestingFabWidget[] = [
-      {
-        id: 'toggle-i18n',
-        label: 'Show i18n Keys',
-        type: 'action',
-        action,
-      },
-    ]
-
-    const { fixture } = setup(widgets)
-    const button = queryRequired<HTMLButtonElement>(fixture, '.sc-testing-fab__action')
-    button.click()
-
-    expect(action).toHaveBeenCalledTimes(1)
   })
 
   test('loads saved FAB position from local storage', () => {

--- a/libs/components/src/lib/testing-fab/testing-fab.component.spec.ts
+++ b/libs/components/src/lib/testing-fab/testing-fab.component.spec.ts
@@ -1,0 +1,202 @@
+import { Component } from '@angular/core'
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { DefaultUrlSerializer, NavigationEnd, Router } from '@angular/router'
+import { LocalStorage } from '@shiftcode/ngx-core'
+import { Subject } from 'rxjs'
+import { describe, expect, test, vi } from 'vitest'
+
+import { TestingFabComponent } from './testing-fab.component'
+import { TESTING_FAB_WIDGETS } from './testing-fab-config.token'
+import type { TestingFabWidget } from './testing-fab-widget.type'
+
+@Component({
+  selector: 'sc-test-custom-widget',
+  template: `<div data-test-id="custom-widget">custom</div>`,
+  standalone: true,
+})
+class TestCustomWidgetComponent {}
+
+const serializer = new DefaultUrlSerializer()
+function queryRequired<TElement extends Element>(
+  fixture: ComponentFixture<TestingFabComponent>,
+  selector: string,
+): TElement {
+  const element = (fixture.nativeElement as HTMLElement).querySelector<TElement>(selector)
+  if (!element) {
+    throw new Error(`Expected element for selector "${selector}"`)
+  }
+
+  return element
+}
+
+function setup(widgets: readonly TestingFabWidget[], url = '/', localStorageValue: unknown = null) {
+  const routerEvents = new Subject<NavigationEnd>()
+  const routerMock = {
+    events: routerEvents.asObservable(),
+    url,
+    parseUrl: vi.fn<typeof serializer.parse>((value) => serializer.parse(value)),
+    navigate: vi.fn().mockResolvedValue(true),
+  } as unknown as Router
+  const localStorageMock = {
+    persistent: true,
+    observe: vi.fn(),
+    setItem: vi.fn(),
+    getItem: vi.fn().mockReturnValue(localStorageValue),
+    delete: vi.fn(),
+    clear: vi.fn(),
+    keys: vi.fn().mockReturnValue([]),
+  } as unknown as LocalStorage
+
+  TestBed.configureTestingModule({
+    imports: [TestingFabComponent],
+    providers: [
+      { provide: TESTING_FAB_WIDGETS, useValue: widgets },
+      { provide: Router, useValue: routerMock },
+      { provide: LocalStorage, useValue: localStorageMock },
+    ],
+  })
+
+  const fixture = TestBed.createComponent(TestingFabComponent)
+  TestBed.tick()
+
+  return { fixture, routerMock, routerEvents, localStorageMock }
+}
+
+describe('TestingFabComponent', () => {
+  test('renders select widget and uses URL query parameter as selected value', () => {
+    const widgets: readonly TestingFabWidget[] = [
+      {
+        id: 'env',
+        label: 'Backend Environment',
+        type: 'select-query-param',
+        queryParam: 'env',
+        options: [
+          { label: 'QA', value: 'qa' },
+          { label: 'Prod', value: 'prod' },
+        ],
+      },
+    ]
+
+    const { fixture, routerEvents } = setup(widgets, '/?env=qa')
+    routerEvents.next(new NavigationEnd(1, '/?env=qa', '/?env=qa'))
+    fixture.detectChanges()
+    const select = queryRequired<HTMLSelectElement>(fixture, 'select')
+    expect(select.value).toBe('qa')
+  })
+
+  test('updates query parameters when select widget value changes', () => {
+    const widgets: readonly TestingFabWidget[] = [
+      {
+        id: 'env',
+        label: 'Backend Environment',
+        type: 'select-query-param',
+        queryParam: 'env',
+        options: [
+          { label: 'QA', value: 'qa' },
+          { label: 'Prod', value: 'prod' },
+        ],
+      },
+    ]
+
+    const { fixture, routerMock } = setup(widgets, '/?env=qa')
+    const select = queryRequired<HTMLSelectElement>(fixture, 'select')
+    select.value = 'prod'
+    select.dispatchEvent(new Event('change'))
+
+    expect(routerMock.navigate).toHaveBeenCalledWith([], {
+      queryParams: { env: 'prod' },
+      queryParamsHandling: 'merge',
+    })
+
+    select.value = ''
+    select.dispatchEvent(new Event('change'))
+
+    expect(routerMock.navigate).toHaveBeenNthCalledWith(2, [], {
+      queryParams: { env: null },
+      queryParamsHandling: 'merge',
+    })
+  })
+
+  test('forces hard reload when configured on select widget', () => {
+    const widgets: readonly TestingFabWidget[] = [
+      {
+        id: 'env',
+        label: 'Backend Environment',
+        type: 'select-query-param',
+        queryParam: 'env',
+        hardReload: true,
+        options: [
+          { label: 'QA', value: 'qa' },
+          { label: 'Prod', value: 'prod' },
+        ],
+      },
+    ]
+
+    const { fixture, routerMock } = setup(widgets, '/?env=qa')
+    const select = queryRequired<HTMLSelectElement>(fixture, 'select')
+    select.value = 'prod'
+    expect(() => select.dispatchEvent(new Event('change'))).not.toThrow()
+
+    expect(routerMock.navigate).not.toHaveBeenCalled()
+  })
+
+  test('renders a custom component widget', () => {
+    const widgets: readonly TestingFabWidget[] = [
+      {
+        id: 'custom',
+        label: 'Custom Widget',
+        type: 'custom-component',
+        component: TestCustomWidgetComponent,
+      },
+    ]
+
+    const { fixture } = setup(widgets)
+    const customWidget = queryRequired<HTMLElement>(fixture, '[data-test-id="custom-widget"]')
+    expect(customWidget).not.toBeNull()
+  })
+
+  test('runs action widgets when clicked', () => {
+    const action = vi.fn()
+    const widgets: readonly TestingFabWidget[] = [
+      {
+        id: 'toggle-i18n',
+        label: 'Show i18n Keys',
+        type: 'action',
+        action,
+      },
+    ]
+
+    const { fixture } = setup(widgets)
+    const button = queryRequired<HTMLButtonElement>(fixture, '.sc-testing-fab__action')
+    button.click()
+
+    expect(action).toHaveBeenCalledTimes(1)
+  })
+
+  test('loads saved FAB position from local storage', () => {
+    const { fixture } = setup([], '/', 'top-left')
+    const host = fixture.nativeElement as HTMLElement
+    expect(host.classList.contains('sc-testing-fab--top-left')).toBe(true)
+  })
+
+  test('stores and applies dropped position when dragging to another corner', () => {
+    const { fixture, localStorageMock } = setup([])
+    const button = queryRequired<HTMLButtonElement>(fixture, '.sc-testing-fab__trigger')
+    const createPointerEvent = (type: string, x: number, y: number) =>
+      new (globalThis.PointerEvent ?? MouseEvent)(type, {
+        bubbles: true,
+        button: 0,
+        clientX: x,
+        clientY: y,
+      })
+
+    button.dispatchEvent(createPointerEvent('pointerdown', window.innerWidth - 20, window.innerHeight - 20))
+    button.dispatchEvent(createPointerEvent('pointermove', 20, 20))
+    button.dispatchEvent(createPointerEvent('pointerup', 20, 20))
+    fixture.detectChanges()
+
+    const host = fixture.nativeElement as HTMLElement
+    expect(host.classList.contains('sc-testing-fab--top-left')).toBe(true)
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('sc-testing-fab.position', 'top-left')
+  })
+})

--- a/libs/components/src/lib/testing-fab/testing-fab.component.ts
+++ b/libs/components/src/lib/testing-fab/testing-fab.component.ts
@@ -3,10 +3,11 @@ import { ChangeDetectionStrategy, Component, computed, effect, inject, signal } 
 import { toSignal } from '@angular/core/rxjs-interop'
 import { NavigationEnd, Router } from '@angular/router'
 import { filterIfInstanceOf, LocalStorage, ORIGIN } from '@shiftcode/ngx-core'
+import { isDefined } from '@shiftcode/utilities'
 import { map, startWith } from 'rxjs'
 
 import { TESTING_FAB_WIDGETS } from './testing-fab-config.token'
-import { TestingFabSelectQueryParamWidget } from './testing-fab-widget.type'
+import { TestingFabSelectQueryParamWidget, TestingFabToggleQueryParamWidget } from './testing-fab-widget.type'
 
 const FAB_POSITIONS = ['top-left', 'top-right', 'bottom-left', 'bottom-right'] as const
 type TestingFabPosition = (typeof FAB_POSITIONS)[number]
@@ -21,6 +22,10 @@ function parsePosition(value: unknown): TestingFabPosition | null {
   }
 
   return null
+}
+
+function isToggleQueryParamValueTruthy(value: string): boolean {
+  return value === 'true' || value === '1' || value === ''
 }
 
 @Component({
@@ -59,13 +64,23 @@ export class TestingFabComponent {
     { initialValue: new URLSearchParams() },
   )
 
-  protected readonly qpWidgetValues = computed((): Record<string, string> => {
+  protected readonly qpWidgetValues = computed((): Record<string, string | boolean> => {
     const qp = this.queryParams()
-    return Object.fromEntries(
-      this.widgets
-        .filter((w) => w.type === 'select-query-param')
-        .map((w) => [w.id, qp.get(w.queryParam) ?? ''] as const),
-    )
+    const valueEntries = this.widgets
+      .map((w): readonly [string, string | boolean] | null => {
+        switch (w.type) {
+          case 'select-query-param':
+            return [w.id, qp.get(w.queryParam) ?? '']
+          case 'toggle-query-param':
+            return [w.id, qp.has(w.queryParam) ? isToggleQueryParamValueTruthy(qp.get(w.queryParam) ?? '') : false]
+          case 'custom-component':
+            return null
+          default:
+            return w
+        }
+      })
+      .filter(isDefined)
+    return Object.fromEntries(valueEntries)
   })
 
   constructor() {
@@ -152,6 +167,29 @@ export class TestingFabComponent {
     void this.router.navigate([], {
       queryParams: {
         [widget.queryParam]: nextValue || null,
+      },
+      queryParamsHandling: 'merge',
+    })
+  }
+
+  protected setToggleQueryParam(widget: TestingFabToggleQueryParamWidget, event: Event): void {
+    const nextEnabled = (event.target as HTMLInputElement).checked
+    const nextValue = nextEnabled ? 'true' : null
+
+    if (widget.hardReload) {
+      const url = new URL(window.location.href)
+      if (nextValue) {
+        url.searchParams.set(widget.queryParam, nextValue)
+      } else {
+        url.searchParams.delete(widget.queryParam)
+      }
+      window.location.assign(url.toString())
+      return
+    }
+
+    void this.router.navigate([], {
+      queryParams: {
+        [widget.queryParam]: nextValue,
       },
       queryParamsHandling: 'merge',
     })

--- a/libs/components/src/lib/testing-fab/testing-fab.component.ts
+++ b/libs/components/src/lib/testing-fab/testing-fab.component.ts
@@ -1,0 +1,165 @@
+import { NgComponentOutlet } from '@angular/common'
+import { ChangeDetectionStrategy, Component, computed, effect, inject, signal } from '@angular/core'
+import { toSignal } from '@angular/core/rxjs-interop'
+import { NavigationEnd, Router } from '@angular/router'
+import { filterIfInstanceOf, LocalStorage, ORIGIN } from '@shiftcode/ngx-core'
+import { map, startWith } from 'rxjs'
+
+import { TESTING_FAB_WIDGETS } from './testing-fab-config.token'
+import { TestingFabSelectQueryParamWidget } from './testing-fab-widget.type'
+
+const FAB_POSITIONS = ['top-left', 'top-right', 'bottom-left', 'bottom-right'] as const
+type TestingFabPosition = (typeof FAB_POSITIONS)[number]
+
+const DEFAULT_POSITION: TestingFabPosition = 'bottom-right'
+const POSITION_STORAGE_KEY = 'sc-testing-fab.position'
+const DRAG_THRESHOLD_PX = 4
+
+function parsePosition(value: unknown): TestingFabPosition | null {
+  if (FAB_POSITIONS.includes(value as any)) {
+    return value as TestingFabPosition
+  }
+
+  return null
+}
+
+@Component({
+  selector: 'sc-testing-fab',
+  standalone: true,
+  imports: [NgComponentOutlet],
+  styleUrls: ['./testing-fab.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './testing-fab.component.html',
+  host: {
+    class: 'sc-testing-fab',
+    '[class.sc-testing-fab--top-left]': "position() === 'top-left'",
+    '[class.sc-testing-fab--top-right]': "position() === 'top-right'",
+    '[class.sc-testing-fab--bottom-left]': "position() === 'bottom-left'",
+    '[class.sc-testing-fab--bottom-right]': "position() === 'bottom-right'",
+  },
+})
+export class TestingFabComponent {
+  private readonly router = inject(Router)
+  private readonly origin = inject(ORIGIN)
+  private readonly localStorage = inject(LocalStorage)
+  private dragState: { pointerId: number; startX: number; startY: number; moved: boolean } | null = null
+  private preventNextClick = false
+  protected readonly widgets = inject(TESTING_FAB_WIDGETS)
+  protected readonly position = signal<TestingFabPosition>(
+    parsePosition(this.localStorage.getItem(POSITION_STORAGE_KEY)) ?? DEFAULT_POSITION,
+  )
+
+  protected readonly queryParams = toSignal(
+    this.router.events.pipe(
+      filterIfInstanceOf(NavigationEnd),
+      map((ev) => ev.urlAfterRedirects),
+      startWith(this.router.url),
+      map((path) => URL.parse(path, this.origin)?.searchParams ?? new URLSearchParams()),
+    ),
+    { initialValue: new URLSearchParams() },
+  )
+
+  protected readonly qpWidgetValues = computed((): Record<string, string> => {
+    const qp = this.queryParams()
+    return Object.fromEntries(
+      this.widgets
+        .filter((w) => w.type === 'select-query-param')
+        .map((w) => [w.id, qp.get(w.queryParam) ?? ''] as const),
+    )
+  })
+
+  constructor() {
+    effect(() => this.localStorage.setItem(POSITION_STORAGE_KEY, this.position()))
+  }
+
+  protected onTriggerPointerDown(event: PointerEvent): void {
+    if (event.button !== 0) {
+      return
+    }
+
+    this.dragState = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      moved: false,
+    }
+    ;(event.currentTarget as HTMLElement | null)?.setPointerCapture?.(event.pointerId)
+  }
+
+  protected onTriggerPointerMove(event: PointerEvent): void {
+    if (!this.dragState || this.dragState.pointerId !== event.pointerId) {
+      return
+    }
+
+    if (!this.dragState.moved) {
+      const deltaX = Math.abs(event.clientX - this.dragState.startX)
+      const deltaY = Math.abs(event.clientY - this.dragState.startY)
+      this.dragState.moved = deltaX > DRAG_THRESHOLD_PX || deltaY > DRAG_THRESHOLD_PX
+    }
+  }
+
+  protected onTriggerPointerUp(event: PointerEvent): void {
+    if (!this.dragState || this.dragState.pointerId !== event.pointerId) {
+      return
+    }
+
+    const { moved } = this.dragState
+    this.dragState = null
+    ;(event.currentTarget as HTMLElement | null)?.releasePointerCapture?.(event.pointerId)
+
+    if (!moved) {
+      return
+    }
+
+    this.preventNextClick = true
+    this.position.set(this.positionFromCoordinates(event.clientX, event.clientY))
+  }
+
+  protected onTriggerPointerCancel(event: PointerEvent): void {
+    if (!this.dragState || this.dragState.pointerId !== event.pointerId) {
+      return
+    }
+
+    this.dragState = null
+    ;(event.currentTarget as HTMLElement | null)?.releasePointerCapture?.(event.pointerId)
+  }
+
+  protected onTriggerClick(event: MouseEvent): void {
+    if (!this.preventNextClick) {
+      return
+    }
+
+    event.preventDefault()
+    event.stopPropagation()
+    this.preventNextClick = false
+  }
+
+  protected setQueryParam(widget: TestingFabSelectQueryParamWidget, event: Event) {
+    const nextValue = (event.target as HTMLSelectElement).value
+
+    if (widget.hardReload) {
+      const url = new URL(window.location.href)
+      if (nextValue) {
+        url.searchParams.set(widget.queryParam, nextValue)
+      } else {
+        url.searchParams.delete(widget.queryParam)
+      }
+
+      window.location.assign(url.toString())
+      return
+    }
+
+    void this.router.navigate([], {
+      queryParams: {
+        [widget.queryParam]: nextValue || null,
+      },
+      queryParamsHandling: 'merge',
+    })
+  }
+
+  private positionFromCoordinates(x: number, y: number): TestingFabPosition {
+    const vertical = y <= window.innerHeight / 2 ? 'top' : 'bottom'
+    const horizontal = x <= window.innerWidth / 2 ? 'left' : 'right'
+    return `${vertical}-${horizontal}`
+  }
+}

--- a/libs/components/src/lib/testing-fab/testing-fab.component.ts
+++ b/libs/components/src/lib/testing-fab/testing-fab.component.ts
@@ -59,7 +59,13 @@ export class TestingFabComponent {
       filterIfInstanceOf(NavigationEnd),
       map((ev) => ev.urlAfterRedirects),
       startWith(this.router.url),
-      map((path) => URL.parse(path, this.origin)?.searchParams ?? new URLSearchParams()),
+      map((path) => {
+        try {
+          return new URL(path, this.origin).searchParams
+        } catch {
+          return new URLSearchParams()
+        }
+      }),
     ),
     { initialValue: new URLSearchParams() },
   )

--- a/libs/components/src/public-api.ts
+++ b/libs/components/src/public-api.ts
@@ -40,6 +40,12 @@ export * from './lib/insert-view-ref/insert-view-ref.directive'
 // navigation-class-handler
 export * from './lib/navigation-class-handler/navigation-class-handler'
 
+// testing fab
+export * from './lib/testing-fab/provide-testing-fab'
+export * from './lib/testing-fab/testing-fab.component'
+export * from './lib/testing-fab/testing-fab-config.token'
+export * from './lib/testing-fab/testing-fab-widget.type'
+
 // rx
 export * from './lib/rx/provide-defaults'
 export * from './lib/rx/rx-if.directive'

--- a/libs/components/src/public-api.ts
+++ b/libs/components/src/public-api.ts
@@ -42,8 +42,6 @@ export * from './lib/navigation-class-handler/navigation-class-handler'
 
 // testing fab
 export * from './lib/testing-fab/provide-testing-fab'
-export * from './lib/testing-fab/testing-fab.component'
-export * from './lib/testing-fab/testing-fab-config.token'
 export * from './lib/testing-fab/testing-fab-widget.type'
 
 // rx

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/ngx-core",
-  "version": "15.3.0-pr87.6",
+  "version": "15.3.0-pr87.7",
   "repository": "https://github.com/shiftcode/sc-ng-commons-public",
   "license": "MIT",
   "author": "shiftcode GmbH <team@shiftcode.ch>",

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/ngx-core",
-  "version": "15.3.0-pr87.3",
+  "version": "15.3.0-pr87.4",
   "repository": "https://github.com/shiftcode/sc-ng-commons-public",
   "license": "MIT",
   "author": "shiftcode GmbH <team@shiftcode.ch>",

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/ngx-core",
-  "version": "15.3.0-pr87.4",
+  "version": "15.3.0-pr87.5",
   "repository": "https://github.com/shiftcode/sc-ng-commons-public",
   "license": "MIT",
   "author": "shiftcode GmbH <team@shiftcode.ch>",

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/ngx-core",
-  "version": "15.3.0-pr87.0",
+  "version": "15.3.0-pr87.1",
   "repository": "https://github.com/shiftcode/sc-ng-commons-public",
   "license": "MIT",
   "author": "shiftcode GmbH <team@shiftcode.ch>",

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/ngx-core",
-  "version": "15.3.0-pr87.7",
+  "version": "15.3.0-pr87.8",
   "repository": "https://github.com/shiftcode/sc-ng-commons-public",
   "license": "MIT",
   "author": "shiftcode GmbH <team@shiftcode.ch>",

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/ngx-core",
-  "version": "15.2.1-pr87.0",
+  "version": "15.3.0-pr87.0",
   "repository": "https://github.com/shiftcode/sc-ng-commons-public",
   "license": "MIT",
   "author": "shiftcode GmbH <team@shiftcode.ch>",

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/ngx-core",
-  "version": "15.3.0-pr87.1",
+  "version": "15.3.0-pr87.2",
   "repository": "https://github.com/shiftcode/sc-ng-commons-public",
   "license": "MIT",
   "author": "shiftcode GmbH <team@shiftcode.ch>",

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/ngx-core",
-  "version": "15.3.0-pr87.5",
+  "version": "15.3.0-pr87.6",
   "repository": "https://github.com/shiftcode/sc-ng-commons-public",
   "license": "MIT",
   "author": "shiftcode GmbH <team@shiftcode.ch>",

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/ngx-core",
-  "version": "15.3.0-pr87.2",
+  "version": "15.3.0-pr87.3",
   "repository": "https://github.com/shiftcode/sc-ng-commons-public",
   "license": "MIT",
   "author": "shiftcode GmbH <team@shiftcode.ch>",

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/ngx-core",
-  "version": "15.2.0",
+  "version": "15.2.1-pr87.0",
   "repository": "https://github.com/shiftcode/sc-ng-commons-public",
   "license": "MIT",
   "author": "shiftcode GmbH <team@shiftcode.ch>",


### PR DESCRIPTION
Implements a configurable Testing FAB in `@shiftcode/ngx-components` instead of only documenting terminology.

## Changes Made

- Added `TestingFabComponent` as a floating, always-on-top FAB with an expandable control panel.
- Added `provideTestingFab(...)` for opt-in provisioning.
- Added typed widget contracts for:
  - Action widgets
  - Select query param widgets
  - Custom component widgets
- Implemented URL-authoritative behavior for select-query-param widgets (read/update query params).
- Exported the new Testing FAB APIs via `libs/components/src/public-api.ts`.
- Added focused unit tests for rendering and behavior.
- Updated component docs and corrected glossary acronym capitalization (`URL`, `HTML`) in `CONTEXT.md`.
- Updated `provideTestingFab(...)` to accept either a static widget config or a factory (`ValueOrFactory` pattern).
- Added environment initialization to mount `sc-testing-fab` automatically via `createComponent(...)` and `provideEnvironmentInitializer(...)`.
- Simplified custom-component widgets to render only the component type (removed custom `inputs` support).
- Added `hardReload` support for select-query-param widgets to optionally update the URL and reload directly.
- Migrated template control flow to modern Angular syntax (`@for`, `@switch`, `@let`) and switched toggle behavior to native `popover`.
- Added CSS custom properties for FAB positioning and theming (`inset`, `margin`, `size`, `border-radius`, background/foreground colors, and icon URL with default Shiftcode logo).
- Added/updated unit tests to cover provider config modes and hard-reload behavior.